### PR TITLE
Hotfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Agrego un ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-Agrego un ignore
+imagenes/Thumbs.db

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -2,21 +2,9 @@
 
 ##### COMPORTAMIENTO ACTUAL:
 
-##### PASOS PARA REPRODUCIR LA MEJORA:
-
-1. 
-2. 
-3. 
-
-##### NOTAS EXTRA:
 
 ##### RAMIFICACIÓN (ES):
-dominar
-
-##### HASH/COMMIT:
+master
 
 ##### SISTEMA OPERATIVO:
 
-##### MODULO:
-
-##### OTRAS PERSONALIZACIONES:


### PR DESCRIPTION
##### ¿QUÉ CAMBIO PROPONE?:
Agregue un gitignore para evitar agregar por erro el archivo imagenes/Thumbs.db

##### COMPORTAMIENTO ACTUAL:
Aparece el archivo imagenes/Thumbs.db y no existe o no aparece

##### NOTAS EXTRA:

##### RAMIFICACIÓN (ES):
dominar

##### HASH/COMMIT:

##### SISTEMA OPERATIVO:
Windows 10
##### MODULO:

##### OTRAS PERSONALIZACIONES:
